### PR TITLE
feature/device name blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Alle benötigte Konfiguration wird in der [`config.json`](config.json) vorgenomm
   * `bindpw`: String - Passwort für Login
   * `uid_attribute`: String - LDAP-Attribut, in dem die Telegram-Benutzer-ID gespeichert ist
   * `basedn`: String - DN auf den die Suche nach Benutzerobjekten eingeschränkt werden soll
+* `blacklistedDeviceNames`: Array - Netzwerkgeräte die nicht angezeigt werden sollen (`/details`)
 
 Für eine sichere LDAP-Verbindung über `ldaps` wird außerdem das CA-Zertifikat
 des LDAP-/AD-Servers in der Datei [`activedirectory_CA.pem`](main.js#10)

--- a/config.json
+++ b/config.json
@@ -52,5 +52,10 @@
 		"bindpw": "",
 		"uid_attribute": "extensionAttribute1",
 		"basedn": "DC=activedirectory,DC=example,DC=com"
-	}
+	},
+	"blacklistedDeviceNames": [
+		"Smart Mirror",
+		"Drucker",
+		"Chromecast Seminarraum"
+	]
 }

--- a/main.js
+++ b/main.js
@@ -327,10 +327,20 @@ function showDetails(message) {
 				stats.names.push(client.name);
 			}
 		},
-		function(stats) {
-			return `Geräte online: ${stats.users + stats.guests}\n` +
-				`Namen: ${stats.names.join(', ')}`;
-		}
+        function formatter(stats) {
+            let validNames = [];
+            let blockedNamesCount = 0;
+            for (let i in stats.names) {
+                let name = stats.names[i];
+                if (_.contains(config.blacklistedDeviceNames, name)) {
+                    blockedNamesCount++;
+                } else {
+                    validNames.push(name)
+                }
+            }
+            return `Geräte online: ${stats.users + stats.guests - blockedNamesCount}\n` +
+                `Namen: ${validNames.join(', ')}`;
+        }
 	);
 }
 


### PR DESCRIPTION
Hallo Roman,
ich habe in den "/details"  command einen gerätenamen Filter eingebaut, sodass z.B. der Drucker nicht länger angezeigt wird.
Die blacklist existiert in der config.json Datei und ist im readme dokumentiert.