### PR TITLE
Enable filtering of devices by essid for "/details" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Alle benötigte Konfiguration wird in der [`config.json`](config.json) vorgenomm
   * `bindpw`: String - Passwort für Login
   * `uid_attribute`: String - LDAP-Attribut, in dem die Telegram-Benutzer-ID gespeichert ist
   * `basedn`: String - DN auf den die Suche nach Benutzerobjekten eingeschränkt werden soll
-* `hidden_network_essid`: String - ESSID dessen verbundene Geräte nicht angezeigt werden sollen (`/details`)
+* `excluded_essids`: Array - ESSIDs dessen verbundene Geräte nicht angezeigt werden sollen (`/details`)
 
 Für eine sichere LDAP-Verbindung über `ldaps` wird außerdem das CA-Zertifikat
 des LDAP-/AD-Servers in der Datei [`activedirectory_CA.pem`](main.js#10)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Alle benötigte Konfiguration wird in der [`config.json`](config.json) vorgenomm
   * `bindpw`: String - Passwort für Login
   * `uid_attribute`: String - LDAP-Attribut, in dem die Telegram-Benutzer-ID gespeichert ist
   * `basedn`: String - DN auf den die Suche nach Benutzerobjekten eingeschränkt werden soll
+* `hidden_network_essid`: String - ESSID dessen verbundene Geräte nicht angezeigt werden sollen (`/details`)
 
 Für eine sichere LDAP-Verbindung über `ldaps` wird außerdem das CA-Zertifikat
 des LDAP-/AD-Servers in der Datei [`activedirectory_CA.pem`](main.js#10)

--- a/config.json
+++ b/config.json
@@ -52,5 +52,6 @@
 		"bindpw": "",
 		"uid_attribute": "extensionAttribute1",
 		"basedn": "DC=activedirectory,DC=example,DC=com"
-	}
+	},
+	"hidden_network_essid": "hidden network"
 }

--- a/config.json
+++ b/config.json
@@ -53,5 +53,5 @@
 		"uid_attribute": "extensionAttribute1",
 		"basedn": "DC=activedirectory,DC=example,DC=com"
 	},
-	"hidden_network_essid": "hidden network"
+	"excluded_essids" : ["hidden network"]
 }

--- a/main.js
+++ b/main.js
@@ -319,11 +319,7 @@ function showDetails(message) {
 		function(client) {
 			var stats = this;
 			if (config.excluded_essids.indexOf(client.essid) > -1) {
-<<<<<<< HEAD
 				return;
-=======
-				return
->>>>>>> 868940c... Implement excluded_essids
 			}
 			if (client._is_guest_by_uap) {
 				stats.guests++;

--- a/main.js
+++ b/main.js
@@ -319,7 +319,11 @@ function showDetails(message) {
 		function(client) {
 			var stats = this;
 			if (config.excluded_essids.indexOf(client.essid) > -1) {
+<<<<<<< HEAD
 				return;
+=======
+				return
+>>>>>>> 868940c... Implement excluded_essids
 			}
 			if (client._is_guest_by_uap) {
 				stats.guests++;

--- a/main.js
+++ b/main.js
@@ -318,6 +318,9 @@ function showDetails(message) {
 		'api/s/default/stat/sta',
 		function(client) {
 			var stats = this;
+			if (client.essid === config.hidden_network_essid) {
+				return
+			}
 			if (client._is_guest_by_uap) {
 				stats.guests++;
 			} else {

--- a/main.js
+++ b/main.js
@@ -318,8 +318,8 @@ function showDetails(message) {
 		'api/s/default/stat/sta',
 		function(client) {
 			var stats = this;
-			if (client.essid === config.hidden_network_essid) {
-				return
+			if (config.excluded_essids.indexOf(client.essid) > -1) {
+				return;
 			}
 			if (client._is_guest_by_uap) {
 				stats.guests++;


### PR DESCRIPTION
The "/details" command now makes sure a given device is not connected to the hidden network before outputting it's device name.